### PR TITLE
feat: add annotation editing UI and translate README to Japanese

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,74 +1,80 @@
-# AutoAnot - Automatic Audio Annotation System
+# AutoAnot - 音声自動アノテーションシステム
 
-AutoAnot is a Streamlit-based application for automatic audio recording, annotation, and dataset generation. The application records audio, automatically labels segments based on RMS (Root Mean Square) changes, and allows saving the annotated data as a dataset.
+AutoAnotは、Streamlitベースの音声録音、アノテーション、データセット生成アプリケーションです。音声を録音し、メトリクスの変化に基づいて自動的にセグメントにラベルを付け、アノテーションデータをデータセットとして保存できます。
 
-## Features
+## 機能
 
-- Audio recording with customizable sampling rate and duration
-- Automatic annotation of 1-second audio segments based on RMS change threshold
-- Visual representation of audio waveforms with color-coded annotations (green for "OK", red for "NG")
-- RMS value display for each audio segment
-- Dataset generation and saving as .npz file for machine learning applications
+- カスタマイズ可能なサンプリング周波数と録音時間での音声録音
+- メトリクス変化閾値に基づく1秒音声セグメントの自動アノテーション
+- 色分けされたアノテーション付き音声波形の視覚的表示（緑色="OK"、赤色="NG"）
+- 各音声セグメントのメトリクス値表示（RMS、クルトシス、クレストファクタ）
+- **手動アノテーション編集機能** - 保存前にユーザが各時間セクションのラベルを変更可能
+- 機械学習アプリケーション用の.npzファイルとしてのデータセット生成・保存
 
-## Requirements
+## 必要な環境
 
 - Python 3.x
 - streamlit
 - numpy
 - sounddevice
 - matplotlib
+- scipy
 
-## Installation
+## インストール
 
-Clone the repository and install the required dependencies:
+リポジトリをクローンして必要な依存関係をインストールしてください：
 
 ```bash
-# Clone the repository
+# リポジトリをクローン
 git clone <repository-url>
 cd AutoAnot
 
-# Create and activate a virtual environment (optional but recommended)
+# 仮想環境の作成とアクティベート（推奨）
 python -m venv venv
-source venv/bin/activate  # On Windows: venv\Scripts\activate
+source venv/bin/activate  # Windows: venv\Scripts\activate
 
-# Install dependencies
-pip install streamlit numpy sounddevice matplotlib
+# 依存関係のインストール
+pip install streamlit numpy sounddevice matplotlib scipy
 ```
 
-## Usage
+## 使用方法
 
-1. Run the application:
+1. アプリケーションを起動：
 
 ```bash
-# Option 1: Using the provided script
+# オプション1: 提供されたスクリプトを使用
 chmod +x run_app.sh
 ./run_app.sh
 
-# Option 2: Direct streamlit command
+# オプション2: streamlitコマンドを直接実行
 streamlit run app.py
 ```
 
-2. In the web interface:
-   - Set the sampling frequency (Hz)
-   - Set the recording duration (seconds)
-   - Set the RMS change threshold (%)
-   - Click "Record" to start recording
-   - After recording, review the automatically annotated segments
-   - Click "Save Dataset" to save the annotated data as a dataset.npz file
+2. Webインターフェースでの操作：
+   - サンプリング周波数（Hz）を設定
+   - 録音時間（秒）を設定
+   - 変化の閾値（%）を設定
+   - 使用するメトリクス（RMS、クルトシス、クレストファクタ）を選択
+   - 「録音開始」をクリックして録音を開始
+   - 録音後、自動的にアノテーションされたセグメントを確認
+   - **「アノテーション編集」セクションで各時間セクションのラベルを必要に応じて変更**
+   - 「編集後のラベルで波形を更新」で変更結果を視覚的に確認
+   - 「データセット保存」をクリックしてアノテーションデータをdataset.npzファイルとして保存
 
-## Dataset Format
+## データセット形式
 
-The saved dataset is in .npz format with the following components:
-- `waveforms`: Array of audio segments (shape: number_of_segments × samples_per_segment)
-- `labels`: Array of labels ("OK" or "NG") for each segment
-- `fs`: Sampling frequency used for recording
+保存されるデータセットは.npz形式で、以下のコンポーネントを含みます：
+- `waveforms`: 音声セグメントの配列（形状: セグメント数 × セグメント当たりのサンプル数）
+- `labels`: 各セグメントのラベル配列（"OK"または"NG"）
+- `fs`: 録音に使用されたサンプリング周波数
+- `metric`: 使用されたメトリクスの種類
 
-## Customization
+## カスタマイズ
 
-- Modify the RMS threshold to adjust the sensitivity of automatic annotation
-- Edit `app.py` to change the annotation logic or visualization parameters
-- Modify `run_app.sh` to change server address or add additional streamlit parameters
+- 変化の閾値を調整して自動アノテーションの感度を変更
+- `app.py`を編集してアノテーションロジックや可視化パラメータを変更
+- `run_app.sh`を変更してサーバーアドレスや追加のstreamlitパラメータを設定
 
-## License
+## ライセンス
 
-[Specify your license here]
+[ライセンスを指定してください]

--- a/app.py
+++ b/app.py
@@ -88,12 +88,63 @@ if st.button("録音開始"):
     st.write("各フレームの", metric_choice, "値と自動ラベル:")
     for i, (val, label) in enumerate(zip(metric_values, labels)):
         st.write(f"{i+1}秒: {metric_choice} = {val:.4f}, ラベル = {label}")
+    
+    # アノテーション編集セクション
+    st.subheader("アノテーション編集")
+    st.write("各時間セクションのラベルを必要に応じて変更してください:")
+    
+    # 編集されたラベルを保存するための初期化
+    if 'edited_labels' not in st.session_state:
+        st.session_state['edited_labels'] = labels.copy()
+    
+    # 各セグメントに対してOK/NG選択のUIを表示
+    edited_labels = []
+    for i in range(len(labels)):
+        col1, col2 = st.columns([1, 3])
+        with col1:
+            st.write(f"{i}～{i+1}秒:")
+        with col2:
+            # ラジオボタンで OK/NG を選択
+            current_label = st.session_state['edited_labels'][i] if i < len(st.session_state['edited_labels']) else labels[i]
+            selected_label = st.radio(
+                f"ラベル選択 ({i}～{i+1}秒)",
+                options=["OK", "NG"],
+                index=0 if current_label == "OK" else 1,
+                key=f"label_radio_{i}",
+                horizontal=True
+            )
+            edited_labels.append(selected_label)
+    
+    # 編集されたラベルをセッションステートに保存
+    st.session_state['edited_labels'] = edited_labels
+    
+    # 編集後のラベルで波形を再表示
+    if st.button("編集後のラベルで波形を更新"):
+        fig, ax = plt.subplots(figsize=(10, 4))
+        t = np.linspace(0, duration, int(duration * fs))
+        ax.plot(t, audio_data, color='gray', alpha=0.5)
+        
+        for i, segment in enumerate(segments):
+            start_time = i
+            end_time = i + 1
+            seg_t = np.linspace(start_time, end_time, len(segment))
+            color = "green" if edited_labels[i] == "OK" else "red"
+            ax.plot(seg_t, segment, color=color, linewidth=2)
+            ax.text((start_time + end_time) / 2, np.max(segment), edited_labels[i],
+                    color=color, fontsize=12, ha='center')
+        
+        ax.set_xlabel("Time (s)")
+        ax.set_ylabel("Amplitude")
+        ax.set_title("編集後のアノテーション表示")
+        st.pyplot(fig)
 
 # データセット保存ボタン
 if st.button("データセット保存"):
     if all(key in st.session_state for key in ['segments', 'labels', 'fs', 'metric_choice']):
         segments_array = np.array(st.session_state['segments'])
-        labels_array = np.array(st.session_state['labels'])
+        # 編集されたラベルがある場合はそれを使用、なければ元のラベルを使用
+        final_labels = st.session_state.get('edited_labels', st.session_state['labels'])
+        labels_array = np.array(final_labels)
         save_path = "dataset.npz"  # 必要に応じて絶対パスに変更可
         np.savez(save_path,
                  waveforms=segments_array,
@@ -102,5 +153,6 @@ if st.button("データセット保存"):
                  metric=st.session_state['metric_choice'])
         st.success(f"データセットを保存しました ({save_path})")
         st.write("現在の作業ディレクトリ:", os.getcwd())
+        st.write("保存されたラベル:", final_labels)
     else:
         st.error("保存するデータが見つかりません。まずは録音を実施してください。")


### PR DESCRIPTION
- Add manual annotation editing interface with OK/NG radio buttons for each time segment
- Users can now modify automatic annotations before saving dataset
- Added visualization update button to preview edited annotations  
- Translated README.md to Japanese with new feature documentation
- Maintain existing functionality while adding requested editing capability